### PR TITLE
Update env-inject-lib to 1.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
         <jenkins.core.version>1.480</jenkins.core.version>
-        <envinject-lib.version>1.19</envinject-lib.version>
+        <envinject-lib.version>1.24</envinject-lib.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
Env-inject-lib 1.23 was using hudson.matrix.MatrixRun directly, but with a recent jenkins-core matrix plugin is not anymore in the jenkins-core but on a separate plugin.
See:
https://github.com/jenkinsci/envinject-lib/pull/7

@reviewbybees 
