### PR TITLE
[JENKINS-27301] Compatibility with Jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,19 +74,6 @@
             <version>${jenkins.core.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-job</artifactId>
-            <version>1.0</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,14 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-war</artifactId>
+            <type>war</type>
+            <version>${jenkins.core.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>envinject-api</artifactId>
             <version>1.0</version>
@@ -70,6 +78,13 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci</groupId>
         <artifactId>jenkins</artifactId>
-        <version>1.21</version>
+        <version>1.37</version>
     </parent>
 
     <groupId>org.jenkins-ci.lib</groupId>
@@ -36,10 +36,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
-        <jenkins.core.version>1.480</jenkins.core.version>
-        <envinject-lib.version>1.19</envinject-lib.version>
+        <jenkins.core.version>1.625.3</jenkins.core.version>
     </properties>
 
     <scm>
@@ -58,15 +55,21 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jenkins-ci.lib</groupId>
-            <artifactId>envinject-lib</artifactId>
-            <version>${envinject-lib.version}</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>envinject-api</artifactId>
+            <version>1.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-test-harness</artifactId>
             <version>${jenkins.core.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>envinject-api</artifactId>
-            <version>1.0</version>
+            <groupId>org.jenkins-ci.lib</groupId>
+            <artifactId>envinject-lib</artifactId>
+            <version>1.25</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
@@ -10,7 +10,7 @@ import hudson.util.StreamTaskListener;
 
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.lib.envinject.EnvInjectException;
-import org.jenkinsci.plugins.envinjectapi.util.EnvVarsResolver;
+import org.jenkinsci.lib.envinject.service.EnvVarsResolver;
 
 import java.io.File;
 import java.io.IOException;
@@ -112,13 +112,10 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
 
     @Deprecated
     protected String resolveEnvVars(String value, AbstractProject project, Node node) throws XTriggerException {
-        return resolveEnvVars(value, (Job)project, node);
-    }
-
-    protected String resolveEnvVars(String value, Job project, Node node) throws XTriggerException {
+        EnvVarsResolver varsResolver = new EnvVarsResolver();
         Map<String, String> envVars;
         try {
-            envVars = EnvVarsResolver.getPollingEnvVars(project, node);
+            envVars = varsResolver.getPollingEnvVars(project, node);
         } catch (EnvInjectException envInjectException) {
             throw new XTriggerException(envInjectException);
         }
@@ -219,8 +216,9 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
                     log.info("Changes found. Scheduling a build.");
                     job.scheduleBuild(0, new XTriggerCause(triggerName, getCause(), true));
                     if (job instanceof Job) {
+                        Job project = (Job) job;
                         for (Action a : getScheduledXTriggerActions(null, log)) {
-                            ((Job) job).addAction(a);
+                            project.addAction(a);
                         }
                     }
                 } else {

--- a/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
@@ -211,7 +211,7 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
                     log.info("Changes found. Scheduling a build.");
                     job.scheduleBuild(0, new XTriggerCause(triggerName, getCause(), true));
                     for (Action a : getScheduledXTriggerActions(null, log)) {
-                        //((Job) job).addAction(a);
+                        ((Job) job).addAction(a);
                     }
                 } else {
                     log.info("No changes.");

--- a/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/AbstractTrigger.java
@@ -110,7 +110,11 @@ public abstract class AbstractTrigger extends Trigger<BuildableItem> implements 
     protected void start(Node pollingNode, BuildableItem project, boolean newInstance, XTriggerLog log) throws XTriggerException {
     }
 
-    @SuppressWarnings("unused")
+    @Deprecated
+    protected String resolveEnvVars(String value, AbstractProject project, Node node) throws XTriggerException {
+        return resolveEnvVars(value, (Job)project, node);
+    }
+
     protected String resolveEnvVars(String value, Job project, Node node) throws XTriggerException {
         Map<String, String> envVars;
         try {

--- a/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCause.java
+++ b/src/main/java/org/jenkinsci/lib/xtrigger/XTriggerCause.java
@@ -6,6 +6,7 @@ import hudson.model.Cause;
 import hudson.model.Hudson;
 import hudson.model.TaskListener;
 import hudson.remoting.Callable;
+import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
@@ -43,7 +44,7 @@ public class XTriggerCause extends Cause {
         final XTriggerCauseAction causeAction = build.getAction(XTriggerCauseAction.class);
         if (causeAction != null) {
             try {
-                Hudson.getInstance().getRootPath().act(new Callable<Void, XTriggerException>() {
+                Hudson.getInstance().getRootPath().act(new MasterToSlaveCallable<Void, XTriggerException>() {
                     @Override
                     public Void call() throws XTriggerException {
                         causeAction.setBuild(build);

--- a/src/test/java/org/jenkinsci/lib/xtrigger/AbstractTriggerTest.java
+++ b/src/test/java/org/jenkinsci/lib/xtrigger/AbstractTriggerTest.java
@@ -23,7 +23,7 @@
  */
 package org.jenkinsci.lib.xtrigger;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import hudson.model.FreeStyleProject;
 
 import org.junit.Rule;
@@ -45,8 +45,8 @@ public class AbstractTriggerTest {
         trigger.start(p, true);
         trigger.run();
 
-        Thread.sleep(60000);
+        j.waitUntilNoActivityUpTo(30000);
 
-        assertTrue(p.getBuilds().size() > 0);
+        assertEquals(1, p.getBuilds().size());
     }
 }

--- a/src/test/java/org/jenkinsci/lib/xtrigger/TestTrigger.java
+++ b/src/test/java/org/jenkinsci/lib/xtrigger/TestTrigger.java
@@ -87,7 +87,7 @@ public class TestTrigger extends AbstractTrigger {
         return "Triggered by test";
     }
 
-    public String getLog() throws Exception {
+    public String getLog() throws IOException, InterruptedException {
         return new FilePath(getLogFile()).readToString();
     }
 

--- a/src/test/java/org/jenkinsci/lib/xtrigger/TestTrigger.java
+++ b/src/test/java/org/jenkinsci/lib/xtrigger/TestTrigger.java
@@ -87,7 +87,7 @@ public class TestTrigger extends AbstractTrigger {
         return "Triggered by test";
     }
 
-    public String getLog() throws IOException {
+    public String getLog() throws Exception {
         return new FilePath(getLogFile()).readToString();
     }
 


### PR DESCRIPTION
Compatibility for `Job`'s. Minimal changes compared to #6. 

- [X] Bump to recent POM
- [X] Migrate from envinject-lib to envinject-plugin
- [X] Compatibility with `Job`/`Run`s

See [JENKINS-27301](https://issues.jenkins-ci.org/browse/JENKINS-27301)