### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/xtriggerapi/AbstractTriggerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/xtriggerapi/AbstractTriggerTest.java
@@ -23,18 +23,19 @@
  */
 package org.jenkinsci.plugins.xtriggerapi;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import hudson.model.FreeStyleProject;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class AbstractTriggerTest {
-    @Rule public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class AbstractTriggerTest {
 
     @Test
-    public void doNotSkipPollingWhenNoLabelSpecified() throws Exception {
+    void doNotSkipPollingWhenNoLabelSpecified(JenkinsRule j) throws Exception {
         j.jenkins.setNumExecutors(0);
         j.createOnlineSlave();
 

--- a/src/test/java/org/jenkinsci/plugins/xtriggerapi/TestTrigger.java
+++ b/src/test/java/org/jenkinsci/plugins/xtriggerapi/TestTrigger.java
@@ -23,38 +23,33 @@
  */
 package org.jenkinsci.plugins.xtriggerapi;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 import hudson.model.Action;
 import hudson.model.Node;
 
 import java.io.File;
 import java.io.IOException;
-
-import org.jenkinsci.plugins.xtriggerapi.AbstractTrigger;
-import org.jenkinsci.plugins.xtriggerapi.XTriggerDescriptor;
-import org.jenkinsci.plugins.xtriggerapi.XTriggerException;
-import org.jenkinsci.plugins.xtriggerapi.XTriggerLog;
-
-import antlr.ANTLRException;
-
+import java.io.Serial;
 /**
  * Explicit trigger for testing purposes.
  *
  * @author ogondza
  */
 public class TestTrigger extends AbstractTrigger {
+    @Serial
     private static final long serialVersionUID = 1L;
 
     private final File log;
     private volatile boolean triggered = false;
 
-    public TestTrigger() throws ANTLRException {
+    public TestTrigger() throws IllegalArgumentException {
         super("* * * * *");
         try {
             log = File.createTempFile("xtrigger", "test");
             log.deleteOnExit();
         } catch (IOException ex) {
-            throw new AssertionError(ex);
+            throw new IllegalArgumentException(ex);
         }
     }
 
@@ -103,6 +98,7 @@ public class TestTrigger extends AbstractTrigger {
 
     private static final Descriptor DESCRIPTOR = new Descriptor();
     public static final class Descriptor extends XTriggerDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Explicit trigger for tests";


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5. Changes include:

* Migrate annotations and imports
* Migrate assertions
* Remove public visibility for test classes and methods
* Minor clean up

I am well aware that this is a quite large changeset however I hope that there is still interest in this PR and it will be reviewed.
If there are any questions, please do not hesitate to ping me.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
